### PR TITLE
chore(standards): add .standards submodule and centralize AI instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,60 +1,16 @@
 <!-- file: .github/copilot-instructions.md -->
-<!-- version: 2.0.1 -->
+<!-- version: 2.1.0 -->
 <!-- guid: 4d5e6f7a-8b9c-0d1e-2f3a-4b5c6d7e8f9a -->
+<!-- last-edited: 2026-06-13 -->
 
-# Copilot/AI Agent Coding Instructions System
+# public-scratch — Additional Context
 
-This repository uses a centralized, modular system for Copilot/AI agent coding,
-documentation, and workflow instructions, following the latest VS Code Copilot
-customization best practices.
+Org-wide coding standards (file headers, language rules, commit format) are at
+**https://github.com/falkcorp/.github** and apply automatically to this repo.
 
-## 🚨 CRITICAL: Documentation Update Protocol
+For full project context: **CLAUDE.md** at the repo root.
 
-This repository no longer uses doc-update scripts. Follow these rules instead:
+## Project overview
 
-- Edit documentation directly in the files within this repository.
-- Keep the required file header (file path, version, guid) and bump the version on any change.
-- Do not use create-doc-update.sh or related scripts; they are retired.
-- Follow `.github/instructions/general-coding.instructions.md` and language-specific instruction files for rules.
-- Prefer VS Code tasks for git operations (Git Add All, Git Commit, Git Push).
-
-## System Overview
-
-- **General rules**: `.github/instructions/general-coding.instructions.md`
-  (applies to all files)
-- **Language/task-specific rules**: `.github/instructions/*.instructions.md`
-  (with `applyTo` frontmatter)
-- **Prompt files**: `.github/prompts/` (for Copilot/AI prompt customization)
-- **Agent-specific docs**: `.github/AGENTS.md`, `.github/CLAUDE.md`, etc.
-  (pointers to this system)
-- **VS Code integration**: `.vscode/copilot/` contains symlinks to canonical
-  `.github/instructions/` files for VS Code Copilot features
-
-## How It Works
-
-- **General instructions** are always included for all files and languages.
-- **Language/task-specific instructions** extend the general rules and use the
-  `applyTo` field to target file globs (e.g., `**/*.go`).
-- **All code style, documentation, and workflow rules are now found exclusively
-  in `.github/instructions/*.instructions.md` files.**
-- **Prompt files** are stored in `.github/prompts/` and can reference
-  instructions as needed.
-- **Agent docs** (e.g., AGENTS.md) point to `.github/` as the canonical source
-  for all rules.
-- **VS Code** uses symlinks in `.vscode/copilot/` to include these instructions
-  for Copilot customization.
-
-## For Contributors
-
-- **Edit or add rules** in `.github/instructions/` only. Do not use or reference
-  any `code-style-*.md` files; these are obsolete.
-- **Add new prompts** in `.github/prompts/`.
-- **Update agent docs** to reference this system.
-- **Do not duplicate rules**; always reference the general instructions from
-  specific ones.
-- **See `.github/README.md`** for a human-friendly summary and contributor
-  guide.
-
-For full details, see the
-[general coding instructions](instructions/general-coding.instructions.md) and
-language-specific files in `.github/instructions/`.
+Public scratch/experiments repository containing miscellaneous scripts,
+configurations, and experiments. Language: Various.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule ".standards"]
 	path = .standards
-	url = https://github.com/falkcarp/.github
+	url = https://github.com/falkcorp/.github

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".standards"]
+	path = .standards
+	url = https://github.com/falkcarp/.github

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,18 @@
+<!-- file: CLAUDE.md -->
+<!-- version: 1.0.0 -->
+<!-- guid: b2c3d4e5-f6a7-4b8c-9d0e-1f2a3b4c5d6e -->
+<!-- last-edited: 2026-06-13 -->
+
+# public-scratch
+
+Public scratch/experiments repository containing miscellaneous scripts,
+configurations, and experiments.
+
+## Coding Standards
+
+Org-wide coding standards are in the `.standards/` git submodule (cloned from `https://github.com/falkcorp/.github`).
+Always clone with `git clone --recurse-submodules` so these are available.
+
+Key files:
+- **File headers (MANDATORY):** `.standards/instructions/file-headers.md`
+- **Commit format:** `.standards/instructions/commit-messages.md`


### PR DESCRIPTION
## Summary

- Adds `.standards/` git submodule → `falkcorp/.github` (org-wide coding standards)
- Slims `.github/copilot-instructions.md` to repo-specific stub only (removes template boilerplate)
- Creates `CLAUDE.md` to reference `.standards/instructions/` for coding standards

After merging: `git clone --recurse-submodules` auto-populates `.standards/` with coding standards.

## Test plan
- [ ] `.gitmodules` contains `.standards` → `https://github.com/falkcorp/.github`
- [ ] `copilot-instructions.md` is ≤25 lines and references CLAUDE.md
- [ ] `CLAUDE.md` has `## Coding Standards` section referencing `.standards/`